### PR TITLE
Correctly handle multi-byte characters in string encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /instant-xml/target
 /instant-xml-macros/target
 Cargo.lock
+**/.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["instant-xml", "instant-xml-macros"]
+resolver = "2"

--- a/instant-xml-macros/Cargo.toml
+++ b/instant-xml-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml-macros"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.58"
 workspace = ".."

--- a/instant-xml-macros/src/de.rs
+++ b/instant-xml-macros/src/de.rs
@@ -584,8 +584,9 @@ fn named_field<'a>(
         });
     }
 
+    let val_name = Ident::new(&format!("__value{index}"), Span::call_site());
     declare_values.extend(quote!(
-        let mut #enum_name = <#no_lifetime_type as FromXml>::Accumulator::default();
+        let mut #val_name = <#no_lifetime_type as FromXml>::Accumulator::default();
     ));
 
     let deserialize_with = field_meta
@@ -614,14 +615,14 @@ fn named_field<'a>(
             tokens.r#match.extend(quote!(
                 __Elements::#enum_name => {
                     let mut nested = deserializer.nested(data);
-                    #with(&mut #enum_name, #field_str, &mut nested)?;
+                    #with(&mut #val_name, #field_str, &mut nested)?;
                 },
             ));
         } else if field_meta.direct {
             direct.extend(quote!(
                 Node::Text(text) => {
                     let mut nested = deserializer.for_node(Node::Text(text));
-                    <#no_lifetime_type>::deserialize(&mut #enum_name, #field_str, &mut nested)?;
+                    <#no_lifetime_type>::deserialize(&mut #val_name, #field_str, &mut nested)?;
                 }
             ));
         } else {
@@ -629,11 +630,11 @@ fn named_field<'a>(
                 __Elements::#enum_name => match <#no_lifetime_type as FromXml>::KIND {
                     Kind::Element => {
                         let mut nested = deserializer.nested(data);
-                        <#no_lifetime_type>::deserialize(&mut #enum_name, #field_str, &mut nested)?;
+                        <#no_lifetime_type>::deserialize(&mut #val_name, #field_str, &mut nested)?;
                     }
                     Kind::Scalar => {
                         let mut nested = deserializer.nested(data);
-                        <#no_lifetime_type>::deserialize(&mut #enum_name, #field_str, &mut nested)?;
+                        <#no_lifetime_type>::deserialize(&mut #val_name, #field_str, &mut nested)?;
                         nested.ignore()?;
                     }
                 },
@@ -651,21 +652,21 @@ fn named_field<'a>(
             tokens.r#match.extend(quote!(
                 __Attributes::#enum_name => {
                     let mut nested = deserializer.nested(data);
-                    #with(&mut #enum_name, #field_str, &mut nested)?;
+                    #with(&mut #val_name, #field_str, &mut nested)?;
                 },
             ));
         } else {
             tokens.r#match.extend(quote!(
                 __Attributes::#enum_name => {
                     let mut nested = deserializer.for_node(Node::AttributeValue(attr.value));
-                    let new = <#no_lifetime_type as FromXml>::deserialize(&mut #enum_name, #field_str, &mut nested)?;
+                    let new = <#no_lifetime_type as FromXml>::deserialize(&mut #val_name, #field_str, &mut nested)?;
                 },
             ));
         }
     };
 
     return_val.extend(quote!(
-        #field_name: #enum_name.try_done(#field_str)?,
+        #field_name: #val_name.try_done(#field_str)?,
     ));
 
     Ok(FieldData {

--- a/instant-xml-macros/src/lib.rs
+++ b/instant-xml-macros/src/lib.rs
@@ -77,7 +77,7 @@ impl<'input> ContainerMeta<'input> {
     fn xml_generics(&self, borrowed: BTreeSet<syn::Lifetime>) -> Generics {
         let mut xml_generics = self.input.generics.clone();
         let mut xml = syn::LifetimeParam::new(syn::Lifetime::new("'xml", Span::call_site()));
-        xml.bounds.extend(borrowed.into_iter());
+        xml.bounds.extend(borrowed);
         xml_generics.params.push(xml.into());
 
         for param in xml_generics.type_params_mut() {
@@ -243,7 +243,7 @@ fn discard_lifetimes(
                     }
                     syn::Type::Slice(inner) if top => match &*inner.elem {
                         syn::Type::Path(inner) if inner.path.is_ident("u8") => {
-                            borrowed.extend(ty.lifetime.take().into_iter());
+                            borrowed.extend(ty.lifetime.take());
                         }
                         _ => {}
                     },
@@ -251,7 +251,7 @@ fn discard_lifetimes(
                 }
             } else if borrow {
                 // Otherwise, only borrow if the user has requested it.
-                borrowed.extend(ty.lifetime.take().into_iter());
+                borrowed.extend(ty.lifetime.take());
             } else {
                 ty.lifetime = None;
             }

--- a/instant-xml/Cargo.toml
+++ b/instant-xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-xml"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.58"
 workspace = ".."
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 chrono = { version = "0.4.23", optional = true }
-macros = { package = "instant-xml-macros", version = "0.3", path = "../instant-xml-macros" }
+macros = { package = "instant-xml-macros", version = "0.3.2", path = "../instant-xml-macros" }
 thiserror = "1.0.29"
 xmlparser = "0.13.3"
 

--- a/instant-xml/src/impls.rs
+++ b/instant-xml/src/impls.rs
@@ -529,7 +529,7 @@ impl<T: ToXml> ToXml for Option<T> {
 fn encode(input: &str) -> Result<Cow<'_, str>, Error> {
     let mut result = String::with_capacity(input.len());
     let mut last_end = 0;
-    for (start, c) in input.chars().enumerate() {
+    for (start, c) in input.char_indices() {
         let to = match c {
             '&' => "&amp;",
             '"' => "&quot;",
@@ -849,7 +849,7 @@ impl<'xml> FromXml<'xml> for IpAddr {
 
 #[cfg(test)]
 mod tests {
-    use super::decode;
+    use super::*;
 
     #[test]
     fn test_decode() {
@@ -866,5 +866,11 @@ mod tests {
         assert!(decode("&foo;").is_err());
         assert!(decode("&foobar;").is_err());
         assert!(decode("cbdtéd&ampü").is_err());
+    }
+
+    #[test]
+    fn encode_unicode() {
+        let input = "Iñtërnâ&tiônàlizætiøn";
+        assert_eq!(encode(input).unwrap(), "Iñtërnâ&amp;tiônàlizætiøn");
     }
 }


### PR DESCRIPTION
Discovered a bug in encoding multi-byte characters that I ran into while working on RSS feeds. Cleaned up some other warnings that popped up since I last worked on this.