### PR TITLE
Handle Cdata sections

### DIFF
--- a/instant-xml/src/de.rs
+++ b/instant-xml/src/de.rs
@@ -333,6 +333,9 @@ impl<'xml> Iterator for Context<'xml> {
                 Ok(Token::Text { text }) => {
                     return Some(Ok(Node::Text(text.as_str())));
                 }
+                Ok(Token::Cdata { text, .. }) => {
+                    return Some(Ok(Node::Text(text.as_str())));
+                }
                 Ok(Token::Declaration { .. }) => match self.stack.is_empty() {
                     false => return Some(Err(Error::UnexpectedToken(format!("{token:?}")))),
                     true => {}


### PR DESCRIPTION
Handling Cdata sections. 

Currently, if a `Cdata` token is encountered, we'll meet the following error: `unexpected token: Cdata`.  This should be fixed by accounting for `Cdata` tokens in the implementation of `Iterator` for `Context`.

From my understanding of `Cdata` sections, I believe we are only concerned with the text inside any `Cdata` section. My knowledge of XML is very limited, so I could be wildly off with this approach.

Cheers!