### PR TITLE
Map default xml prefix

### DIFF
--- a/instant-xml/src/de.rs
+++ b/instant-xml/src/de.rs
@@ -185,6 +185,13 @@ impl<'xml> Context<'xml> {
     }
 
     fn lookup(&self, prefix: &str) -> Option<&'xml str> {
+        // The prefix xml is by definition bound to the namespace
+        // name http://www.w3.org/XML/1998/namespace
+        // See https://www.w3.org/TR/xml-names/#ns-decl
+        if prefix == "xml" {
+            return Some("http://www.w3.org/XML/1998/namespace");
+        }
+
         self.stack
             .iter()
             .rev()

--- a/instant-xml/tests/de-ns.rs
+++ b/instant-xml/tests/de-ns.rs
@@ -34,6 +34,12 @@ fn default_namespaces() {
         Ok(NestedDe { flag: true })
     );
 
+    // Default namespace not-nested - with xml:lang
+    assert_eq!(
+        from_str("<NestedDe xml:lang=\"en\" xmlns=\"URI\" xmlns:bar=\"BAZ\"><bar:flag>true</bar:flag></NestedDe>"),
+        Ok(NestedDe { flag: true })
+    );
+
     // Default namespace not-nested - wrong namespace
     assert_eq!(
         from_str(


### PR DESCRIPTION
https://www.w3.org/TR/xml-names/#ns-decl

> The prefix xml is by definition bound to the namespace name http://www.w3.org/XML/1998/namespace. It may, but need not, be declared, and must not be undeclared or bound to any other namespace name. Other prefixes must not be bound to this namespace name, and it must not be declared as the default namespace.

I ran into this with the commonly used xml:lang attribute without explicit definition of the xml prefix.